### PR TITLE
Fix iOS tap event

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,5 @@ public getCheckProp() {
 
 ## Demo Setup
 * npm install tns-platform-declarations
-* preparedemo
+* npm preparedemo
 * npm run demo.ios

--- a/app/App_Resources/iOS/Info.plist
+++ b/app/App_Resources/iOS/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiresFullScreen</key>
+	<true/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/checkbox.ios.ts
+++ b/checkbox.ios.ts
@@ -260,6 +260,12 @@ class BEMCheckBoxDelegateImpl extends NSObject implements BEMCheckBoxDelegate {
     public didTapCheckBox(checkBox: BEMCheckBox): void {
       let owner = this._owner.get();
         if (owner) {
+            var eventData = {
+                eventName: "tap",
+                object: owner
+            };
+            
+            owner.notify(eventData);
             owner._onPropertyChangedFromNative(CheckBox.checkedProperty, checkBox.on);
         }
     }

--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -33,7 +33,8 @@ export function onToggleTest(args){
 
 export function onTapTest(args){
     console.log("tap event test");
-    model.updateMessage();
+    let box = <CheckBox>args.object;
+    model.updateMessage(box.checked);
 }
 
 export function onDumpModel(args: any){

--- a/demo/app/main-view-model.ts
+++ b/demo/app/main-view-model.ts
@@ -40,9 +40,9 @@ export class HelloWorldModel extends Observable {
         this.notifyPropertyChange("state", value);
     }
 
-    public updateMessage(){
+    public updateMessage(state){
         this._eventCount++;
-        this.eventLabel = "Triggered " + this._eventCount + " times";
+        this.eventLabel = "Triggered " + this._eventCount + " times, current state:" + state;
     }
 
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -2,15 +2,15 @@
   "nativescript": {
     "id": "org.nativescript.demo",
     "tns-android": {
-      "version": "2.2.0"
+      "version": "2.3.0"
     },
     "tns-ios": {
-      "version": "2.2.1"
+      "version": "2.3.0"
     }
   },
   "dependencies": {
     "nativescript-checkbox": "file:..",
-    "tns-core-modules": "^2.2.1"
+    "tns-core-modules": "^2.3.0"
   },
   "devDependencies": {
     "babel-traverse": "6.7.6",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
 	"name": "nativescript-checkbox",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "NativeScript plugin for checkbox widget.",
 	"main": "checkbox.js",
 	"typings": "index.d.ts",
 	"nativescript": {
 		"platforms": {
-			"android": "2.1.1",
-      "ios": "2.1.1"
+			"android": "2.3",
+      "ios": "2.3"
 		}
 	},
 	"scripts": {

--- a/platforms/ios/nativescriptcheckbox/app/App_Resources/iOS/Info.plist
+++ b/platforms/ios/nativescriptcheckbox/app/App_Resources/iOS/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiresFullScreen</key>
+	<true/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
- Updated to 2.3 min
- Tap event fires if native iOS widget is clicked (Issue: https://github.com/bradmartin/nativescript-checkbox/issues/3) , demo updated to reflect this
- missing "npm" in the demo notes
