### PR TITLE
Added grunt publish script to npm scripts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@ demo-ng/
 screens/
 app/
 hooks/
+.idea/
 .vscode/
 gruntfile.js
 *.png

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-checkbox",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "NativeScript plugin for checkbox widget.",
   "main": "checkbox",
   "typings": "index.d.ts",
@@ -11,6 +11,7 @@
     }
   },
   "scripts": {
+    "publish": "grunt publish",
     "precommit": "lint-staged",
     "build": "tsc",
     "copy.ios": "cp -R checkbox.*.js demo/node_modules/nativescript-checkbox && cd demo && tns run ios --syncAllFiles",


### PR DESCRIPTION
I didn't know grunt was used to publish, so the last version (3.0.0) didn't include the AoT files this plugin requires. This won't happen again.